### PR TITLE
Create install button to add OWA addons

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -772,3 +772,6 @@ body.loading .waiting-modal {
 .download-update:hover {
     cursor: pointer;
 }
+.install {
+    margin-top: 5px 
+}

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -109,9 +109,9 @@ export default class SingleAddon extends React.Component{
                   onClick={(e) => handleOWAInstallation(app.downloadUri)(e)}
                 /> */}
                 <button
-                  onClick={(e) => handleOWAInstallation(app.downloadUri)(e)}
+                  className="btn btn-default alert-success install"
                 >
-                    Ins
+                  Install
                 </button>
               </div>
           }


### PR DESCRIPTION
## JIRA TICKET NAME:
AOM-61: Create install button

### SUMMARY:
An install button has been added to let users directly install OWA addons instead of downloading it.
